### PR TITLE
fixed IllegalStateException when dialog no longer exists when onPostExecute is called

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -1356,7 +1356,11 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
         @Override
         protected void onPostExecute(Boolean status) {
             super.onPostExecute(status);
-            loadingDialog.dismiss();
+            if(loadingDialog.isStateSaved()){
+                loadingDialog.dismissAllowingStateLoss();
+            } else {
+                loadingDialog.dismiss();
+            }
             if (!status) {
                 return;
             }


### PR DESCRIPTION
Fixes the crash (#73) by allowing state loss, only when required.

Might be useful to display a notification to the user while the file is downloading.