### PR TITLE
Fix Crypt config's password salt hint

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CryptConfig.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CryptConfig.java
@@ -142,7 +142,7 @@ public class CryptConfig extends Fragment {
         formContent.addView(password2Template);
         password2InputLayout = password2Template.findViewById(R.id.pass_input_layout);
         password2InputLayout.setHintEnabled(true);
-        password2InputLayout.setHint(getString(R.string.crypt_pass_hint));
+        password2InputLayout.setHint(getString(R.string.crypt_pass2_hint));
         password2Template.findViewById(R.id.helper_text).setVisibility(View.VISIBLE);
         password2 = password2Template.findViewById(R.id.pass);
 


### PR DESCRIPTION
`crypt_pass2_hint` already exists in `rcloneExplorer\app\src\main\res\values\strings.xml` but wasn't used.
I haven't done a build to verify, but this fix should hopefully do the trick.