### PR TITLE
Fixed crash when rotating device while sort popup is open

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/SortDialog.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/SortDialog.java
@@ -55,6 +55,10 @@ public class SortDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         if(savedInstanceState != null){
             isDarkTheme = savedInstanceState.getBoolean("isDarkTheme");
+            title = savedInstanceState.getInt("title");
+            positiveText = savedInstanceState.getInt("positiveText");
+            negativeText = savedInstanceState.getInt("negativeText");
+            sortOrder = savedInstanceState.getInt("sortOrder");
         }
 
         AlertDialog.Builder builder;
@@ -93,6 +97,10 @@ public class SortDialog extends DialogFragment {
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean("isDarkTheme", isDarkTheme);
+        outState.putInt("title", title);
+        outState.putInt("positiveText", positiveText);
+        outState.putInt("negativeText", negativeText);
+        outState.putInt("sortOrder", sortOrder);
     }
 
     public SortDialog setListener(OnClickListener l) {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/SortDialog.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/SortDialog.java
@@ -45,7 +45,7 @@ public class SortDialog extends DialogFragment {
     public void onAttach(Context context) {
         super.onAttach(context);
         // reacquire FragmentActivity when recreated implicitly
-        if(this.context == null && context instanceof FragmentActivity){
+        if (this.context == null && context instanceof FragmentActivity) {
             this.context = context;
         }
     }
@@ -53,7 +53,7 @@ public class SortDialog extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        if(savedInstanceState != null){
+        if (savedInstanceState != null) {
             isDarkTheme = savedInstanceState.getBoolean("isDarkTheme");
             title = savedInstanceState.getInt("title");
             positiveText = savedInstanceState.getInt("positiveText");

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/SortDialog.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/SortDialog.java
@@ -41,10 +41,22 @@ public class SortDialog extends DialogFragment {
         isDarkTheme = false;
     }
 
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        // reacquire FragmentActivity when recreated implicitly
+        if(this.context == null && context instanceof FragmentActivity){
+            this.context = context;
+        }
+    }
 
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
+        if(savedInstanceState != null){
+            isDarkTheme = savedInstanceState.getBoolean("isDarkTheme");
+        }
+
         AlertDialog.Builder builder;
         if (isDarkTheme) {
             builder = new AlertDialog.Builder(context, R.style.DarkDialogTheme);
@@ -75,6 +87,12 @@ public class SortDialog extends DialogFragment {
 
         builder.setView(view);
         return builder.create();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean("isDarkTheme", isDarkTheme);
     }
 
     public SortDialog setListener(OnClickListener l) {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -269,8 +269,8 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
         super.onStart();
         registerReceivers();
         Fragment sortDialog;
-        if(getFragmentManager() != null
-                && (sortDialog = getFragmentManager().findFragmentByTag("sort dialog")) instanceof SortDialog){
+        if (getFragmentManager() != null
+                && (sortDialog = getFragmentManager().findFragmentByTag("sort dialog")) instanceof SortDialog) {
             ((SortDialog) sortDialog).setListener(new SortDialog.OnClickListener() {
                 @Override
                 public void onPositiveButtonClick(int sortById, int sortOrderId) {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -268,6 +268,19 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
     public void onStart() {
         super.onStart();
         registerReceivers();
+        Fragment sortDialog;
+        if(getFragmentManager() != null
+                && (sortDialog = getFragmentManager().findFragmentByTag("sort dialog")) instanceof SortDialog){
+            ((SortDialog) sortDialog).setListener(new SortDialog.OnClickListener() {
+                @Override
+                public void onPositiveButtonClick(int sortById, int sortOrderId) {
+                    if (!directoryObject.isDirectoryContentEmpty()) {
+                        sortSelected(sortById, sortOrderId);
+                    }
+                }
+            });
+        }
+
         if (showThumbnails) {
             startThumbnailService();
         }


### PR DESCRIPTION
App crashes on rotation when sort popup is open due to being recreated without a FragmentActivity context by Android.

Fixed by re-acquiring FragmentActivity when attached without context. Also saves/restores dark theme (otherwise, Android recreates the dialog in default state). Selection state is managed by Android itself.