### PR TITLE
Fix directory name encryption switch behavior when creating Crypt Remote

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CryptConfig.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CryptConfig.java
@@ -235,13 +235,20 @@ public class CryptConfig extends Fragment {
         View switchTemplate = View.inflate(context, R.layout.config_form_template_switch, null);
         switchTemplate.setLayoutParams(params);
         formContent.addView(switchTemplate);
+        directoryEncryption = "false";
         ((Switch)switchTemplate.findViewById(R.id.flip_switch)).setChecked(false);
         switchTemplate.findViewById(R.id.switch_layout).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 Switch s = v.findViewById(R.id.flip_switch);
-                directoryEncryption = (s.isChecked()) ? "false" : "true";
                 s.setChecked(!s.isChecked());
+            }
+        });
+        ((Switch)switchTemplate.findViewById(R.id.flip_switch)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Switch s = buttonView.findViewById(R.id.flip_switch);
+                directoryEncryption = (s.isChecked()) ? "true" : "false";
             }
         });
         ((TextView)switchTemplate.findViewById(R.id.switch_text)).setText(R.string.directory_name_encryption_hint);


### PR DESCRIPTION
Two issues which can cause a Crypt Remote creation to fail:
1. No default value set, so if the user doesn't change the toggle, we end up with a null pointer.
2. Toggling only works when pressing on the text/layout area, the actual switch changes state visually but true/false not actually set. directoryEncryption can potentially be kept as null if user presses directly on the toggle.

I've copied the logic from the Settings page (SettingsActivity), and followed how log, crash reporting, and thumbnail switches works, and applied it here.