### PR TITLE
Fix Yandex remote creation

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/RemotesConfigList.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/RemotesConfigList.java
@@ -175,7 +175,7 @@ public class RemotesConfigList extends Fragment {
             @Override
             public void onClick(View v) {
                 RadioButton rb = v.findViewById(R.id.provider_rb);
-                setSelected(rb, "BOX");
+                setSelected(rb, "YANDEX");
             }
         });
 
@@ -269,3 +269,4 @@ public class RemotesConfigList extends Fragment {
 
     }
 }
+


### PR DESCRIPTION
A quick fix for another copy and paste error. Was able to create a Yandex remote without issues after making this change, the underlying stuff works fine.