### PR TITLE
Hide directory mod time for Backblaze B2 remotes

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import ca.pkay.rcloneexplorer.Items.FileItem;
@@ -105,7 +106,12 @@ public class FileExplorerRecyclerViewAdapter extends RecyclerView.Adapter<FileEx
                     .into(holder.fileIcon);
         }
 
-        if ((item.getRemote().equals("dropbox") || item.getRemote().equals("dropbox")) && item.isDir()) {
+        List<String> remotesWithoutDirModTime = Arrays.asList(
+                "Dropbox",
+                "B2"
+        );
+
+        if ((remotesWithoutDirModTime.contains(item.getRemote()) || remotesWithoutDirModTime.contains(item.getRemote())) && item.isDir()) {
             holder.fileModTime.setVisibility(View.GONE);
         } else {
             holder.fileModTime.setVisibility(View.VISIBLE);
@@ -402,3 +408,4 @@ public class FileExplorerRecyclerViewAdapter extends RecyclerView.Adapter<FileEx
         }
     }
 }
+


### PR DESCRIPTION
Taking https://github.com/kaczmarkiewiczp/rcloneExplorer/commit/7db07aacecf3e7a15bb5eebdb52e773ee7764537 a bit further, since Dropbox isn't the only remote with this issue.

Suspecting that other object storage such as Azure Blob Storage or AWS S3 might have the same issue. Someone else can add those to the list later once tested and confirmed.