### PR TITLE
Allow SSH remotes to list directory

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -106,7 +106,7 @@ public class Rclone {
     }
 
     public List<FileItem> getDirectoryContent(String remote, String path) {
-        String remoteAndPath = remote + ":";
+        String remoteAndPath = remote + ":/";
         if (path.compareTo("//" + remote) != 0) {
             remoteAndPath += path;
         }


### PR DESCRIPTION
An example of what can be done to allow SSH remotes to list directory.

This might have unknown consequences for other remotes, although a quick test showed that there was no issues listing files with B2, Dropbox, Onedrive, Pcloud, and Yandex.