### PR TITLE
Changed remote String property to RemoteItem to fix modtime hide fix

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/RemoteDestinationDialog.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/RemoteDestinationDialog.java
@@ -32,6 +32,7 @@ import java.util.Stack;
 import ca.pkay.rcloneexplorer.FileComparators;
 import ca.pkay.rcloneexplorer.Items.DirectoryObject;
 import ca.pkay.rcloneexplorer.Items.FileItem;
+import ca.pkay.rcloneexplorer.Items.RemoteItem;
 import ca.pkay.rcloneexplorer.MainActivity;
 import ca.pkay.rcloneexplorer.R;
 import ca.pkay.rcloneexplorer.Rclone;
@@ -49,7 +50,7 @@ public class RemoteDestinationDialog extends DialogFragment implements  SwipeRef
     private static final String SHARED_PREFS_SORT_ORDER = "ca.pkay.rcexplorer.sort_order";
     private Context context;
     private SwipeRefreshLayout swipeRefreshLayout;
-    private String remote;
+    private RemoteItem remote;
     private boolean isDarkTheme;
     private FileExplorerRecyclerViewAdapter recyclerViewAdapter;
     private Rclone rclone;
@@ -73,7 +74,7 @@ public class RemoteDestinationDialog extends DialogFragment implements  SwipeRef
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         rclone = new Rclone(context);
-        String path = "//" + remote;
+        String path = "//" + remote.getName();
         directoryObject.setPath(path);
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         sortOrder = sharedPreferences.getInt(SHARED_PREFS_SORT_ORDER, SortDialog.ALPHA_ASCENDING);
@@ -163,7 +164,7 @@ public class RemoteDestinationDialog extends DialogFragment implements  SwipeRef
         return this;
     }
 
-    public RemoteDestinationDialog setRemote(String remote) {
+    public RemoteDestinationDialog setRemote(RemoteItem remote) {
         this.remote = remote;
         return this;
     }
@@ -249,7 +250,7 @@ public class RemoteDestinationDialog extends DialogFragment implements  SwipeRef
                                 return;
                             }
                             String newDir;
-                            if (directoryObject.getCurrentPath().equals("//" + remote)) {
+                            if (directoryObject.getCurrentPath().equals("//" + remote.getName())) {
                                 newDir = input;
                             } else {
                                 newDir = directoryObject.getCurrentPath() + "/" + input;
@@ -401,7 +402,7 @@ public class RemoteDestinationDialog extends DialogFragment implements  SwipeRef
         @Override
         protected Boolean doInBackground(String... strings) {
             String newDir = strings[0];
-            return rclone.makeDirectory(remote, newDir);
+            return rclone.makeDirectory(remote.getRemote(), newDir);
         }
 
         @Override

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -1237,7 +1237,7 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
         @Override
         protected List<FileItem> doInBackground(Void... voids) {
             List<FileItem> fileItemList;
-            fileItemList = rclone.getDirectoryContent(remoteName, directoryObject.getCurrentPath());
+            fileItemList = rclone.getDirectoryContent(remote, directoryObject.getCurrentPath());
             return fileItemList;
         }
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/ShareFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/ShareFragment.java
@@ -55,7 +55,7 @@ public class ShareFragment extends Fragment implements  SwipeRefreshLayout.OnRef
     private static final String SHARED_PREFS_SORT_ORDER = "ca.pkay.rcexplorer.sort_order";
     private onShareDestincationSelected listener;
     private Context context;
-    private String remoteName;
+    private RemoteItem remote;
     private String originalToolbarTitle;
     private int sortOrder;
     private Rclone rclone;
@@ -85,12 +85,11 @@ public class ShareFragment extends Fragment implements  SwipeRefreshLayout.OnRef
         if (getArguments() == null) {
             return;
         }
-        RemoteItem remote = getArguments().getParcelable(ARG_REMOTE);
+        remote = getArguments().getParcelable(ARG_REMOTE);
         if (remote == null) {
             return;
         }
-        remoteName = remote.getName();
-        String path = "//" + remoteName;
+        String path = "//" + remote.getName();
 
         if (getContext() == null) {
             return;
@@ -138,7 +137,7 @@ public class ShareFragment extends Fragment implements  SwipeRefreshLayout.OnRef
         breadcrumbView = ((FragmentActivity)context).findViewById(R.id.breadcrumb_view);
         breadcrumbView.setOnClickListener(this);
         breadcrumbView.setVisibility(View.VISIBLE);
-        breadcrumbView.addCrumb(remoteName, "//" + remoteName);
+        breadcrumbView.addCrumb(remote.getName(), "//" + remote.getName());
 
         final TypedValue accentColorValue = new TypedValue ();
         context.getTheme().resolveAttribute (R.attr.colorAccent, accentColorValue, true);
@@ -153,7 +152,7 @@ public class ShareFragment extends Fragment implements  SwipeRefreshLayout.OnRef
         view.findViewById(R.id.select_move).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                listener.onShareDestinationSelected(remoteName, directoryObject.getCurrentPath());
+                listener.onShareDestinationSelected(remote.getName(), directoryObject.getCurrentPath());
             }
         });
         view.findViewById(R.id.new_folder).setOnClickListener(new View.OnClickListener() {
@@ -423,7 +422,7 @@ public class ShareFragment extends Fragment implements  SwipeRefreshLayout.OnRef
                                 return;
                             }
                             String newDir;
-                            if (directoryObject.getCurrentPath().equals("//" + remoteName)) {
+                            if (directoryObject.getCurrentPath().equals("//" + remote.getName())) {
                                 newDir = input;
                             } else {
                                 newDir = directoryObject.getCurrentPath() + "/" + input;
@@ -451,7 +450,7 @@ public class ShareFragment extends Fragment implements  SwipeRefreshLayout.OnRef
         @Override
         protected List<FileItem> doInBackground(Void... voids) {
             List<FileItem> fileItemList;
-            fileItemList = rclone.getDirectoryContent(remoteName, directoryObject.getCurrentPath());
+            fileItemList = rclone.getDirectoryContent(remote, directoryObject.getCurrentPath());
             return fileItemList;
         }
 
@@ -498,7 +497,7 @@ public class ShareFragment extends Fragment implements  SwipeRefreshLayout.OnRef
         @Override
         protected Boolean doInBackground(String... strings) {
             String newDir = strings[0];
-            return rclone.makeDirectory(remoteName, newDir);
+            return rclone.makeDirectory(remote.getName(), newDir);
         }
 
         @Override

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/FileItem.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/FileItem.java
@@ -11,7 +11,7 @@ import java.util.Locale;
 
 public class FileItem implements Parcelable {
 
-    private String remote;
+    private RemoteItem remote;
     private String path;
     private String name;
     private long size;
@@ -20,7 +20,7 @@ public class FileItem implements Parcelable {
     private String humanReadableModTime;
     private boolean isDir;
 
-    public FileItem(String remote, String path, String name, long size, String modTime, boolean isDir) {
+    public FileItem(RemoteItem remote, String path, String name, long size, String modTime, boolean isDir) {
         this.remote = remote;
         this.path = path;
         this.name = name;
@@ -32,7 +32,7 @@ public class FileItem implements Parcelable {
     }
 
     protected FileItem(Parcel in) {
-        remote = in.readString();
+        remote = in.readParcelable(RemoteItem.class.getClassLoader());
         path = in.readString();
         name = in.readString();
         size = in.readLong();
@@ -54,7 +54,7 @@ public class FileItem implements Parcelable {
         }
     };
 
-    public String getRemote() {
+    public RemoteItem getRemote() {
         return remote;
     }
     public String getPath() {
@@ -140,7 +140,7 @@ public class FileItem implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(remote);
+        dest.writeParcelable(remote, 0);
         dest.writeString(path);
         dest.writeString(name);
         dest.writeLong(size);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -105,9 +105,9 @@ public class Rclone {
         log2File.log(stringBuilder.toString());
     }
 
-    public List<FileItem> getDirectoryContent(String remote, String path) {
-        String remoteAndPath = remote + ":";
-        if (path.compareTo("//" + remote) != 0) {
+    public List<FileItem> getDirectoryContent(RemoteItem remote, String path) {
+        String remoteAndPath = remote.getName() + ":";
+        if (path.compareTo("//" + remote.getName()) != 0) {
             remoteAndPath += path;
         }
 
@@ -142,7 +142,7 @@ public class Rclone {
         for (int i = 0; i < results.length(); i++) {
             try {
                 JSONObject jsonObject = results.getJSONObject(i);
-                String filePath = (path.compareTo("//" + remote) == 0) ? "" : path + "/";
+                String filePath = (path.compareTo("//" + remote.getName()) == 0) ? "" : path + "/";
                 filePath += jsonObject.getString("Path");
                 String fileName = jsonObject.getString("Name");
                 long fileSize = jsonObject.getLong("Size");

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
@@ -107,11 +107,12 @@ public class FileExplorerRecyclerViewAdapter extends RecyclerView.Adapter<FileEx
         }
 
         List<String> remotesWithoutDirModTime = Arrays.asList(
-                "Dropbox",
-                "B2"
+                "dropbox",
+                "b2",
+                "hubic"
         );
 
-        if ((remotesWithoutDirModTime.contains(item.getRemote()) || remotesWithoutDirModTime.contains(item.getRemote())) && item.isDir()) {
+        if ((remotesWithoutDirModTime.contains(item.getRemote().getType()) || remotesWithoutDirModTime.contains(item.getRemote().getType())) && item.isDir()) {
             holder.fileModTime.setVisibility(View.GONE);
         } else {
             holder.fileModTime.setVisibility(View.VISIBLE);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import ca.pkay.rcloneexplorer.Items.FileItem;
@@ -105,7 +106,12 @@ public class FileExplorerRecyclerViewAdapter extends RecyclerView.Adapter<FileEx
                     .into(holder.fileIcon);
         }
 
-        if ((item.getRemote().equals("dropbox") || item.getRemote().equals("dropbox")) && item.isDir()) {
+        List<String> remotesWithoutDirModTime = Arrays.asList(
+                "Dropbox",
+                "B2"
+        );
+
+        if ((remotesWithoutDirModTime.contains(item.getRemote()) || remotesWithoutDirModTime.contains(item.getRemote())) && item.isDir()) {
             holder.fileModTime.setVisibility(View.GONE);
         } else {
             holder.fileModTime.setVisibility(View.VISIBLE);
@@ -402,3 +408,4 @@ public class FileExplorerRecyclerViewAdapter extends RecyclerView.Adapter<FileEx
         }
     }
 }
+

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/AliasConfig.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/AliasConfig.java
@@ -180,7 +180,7 @@ public class AliasConfig extends Fragment {
         RemoteDestinationDialog remoteDestinationDialog = new RemoteDestinationDialog()
                 .withContext(context)
                 .setDarkTheme(isDarkTheme)
-                .setRemote(selectedRemote.getName())
+                .setRemote(selectedRemote)
                 .setTitle(R.string.select_path_to_alias)
                 .setPositiveButtonListener(new RemoteDestinationDialog.OnDestinationSelectedListener() {
                     @Override

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CacheConfig.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CacheConfig.java
@@ -368,7 +368,7 @@ public class CacheConfig extends Fragment {
         RemoteDestinationDialog remoteDestinationDialog = new RemoteDestinationDialog()
                 .withContext(context)
                 .setDarkTheme(isDarkTheme)
-                .setRemote(selectedRemote.getName())
+                .setRemote(selectedRemote)
                 .setTitle(R.string.select_path_to_alias)
                 .setPositiveButtonListener(new RemoteDestinationDialog.OnDestinationSelectedListener() {
                     @Override

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CryptConfig.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/CryptConfig.java
@@ -336,7 +336,7 @@ public class CryptConfig extends Fragment {
         RemoteDestinationDialog remoteDestinationDialog = new RemoteDestinationDialog()
                 .withContext(context)
                 .setDarkTheme(isDarkTheme)
-                .setRemote(selectedRemote.getName())
+                .setRemote(selectedRemote)
                 .setTitle(R.string.select_path_to_crypt)
                 .setPositiveButtonListener(new RemoteDestinationDialog.OnDestinationSelectedListener() {
             @Override


### PR DESCRIPTION
Building on top of https://github.com/kaczmarkiewiczp/rcloneExplorer/pull/111 this pr changes treating remote as string to allow access to more specific data, namely correctly assessing the type of a remote of a FileItem. As a result, mod times can be hidden independent from the configured remote name.