### PR TITLE
Fix typo in rclone command when creating Azure Blob Storage remotes

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/Azureblob.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/Azureblob.java
@@ -132,7 +132,7 @@ public class Azureblob extends Fragment {
 
         ArrayList<String> options = new ArrayList<>();
         options.add(name);
-        options.add("Azureblob");
+        options.add("azureblob");
         options.add("account");
         options.add(accountString);
         options.add("key");


### PR DESCRIPTION
Microsoft Azure Blob Storage is `azureblob `, not `Azureblob`.
Setting this incorrectly means `rclone config create` will always fail.