### PR TITLE
Create recyclerViewAdapter during CONFIG_RECREATE to avoid null pointer

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/RemotesFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/RemotesFragment.java
@@ -135,7 +135,7 @@ public class RemotesFragment extends Fragment implements RemotesRecyclerViewAdap
             case CONFIG_RECREATE_REQ_CODE:
                 remotes = rclone.getRemotes();
                 Collections.sort(remotes);
-                recyclerViewAdapter.newData(remotes);
+                recyclerViewAdapter = new RemotesRecyclerViewAdapter(remotes, clickListener, this);
                 refreshFragment();
                 break;
         }


### PR DESCRIPTION
My quick attempt to avoid a null pointer. Perhaps recyclerViewAdapter can be initialized elsewhere.

Steps to reproduce the issue:
1. Fully uninstall app (or clear data and cache from storage)
2. Install app
3. Create your first remote from within app
4. App will crash after first remote is created since recyclerViewAdapter is null

After re-launching the app again, the remote just created will be there and will not crash again since we'll no longer encounter the CONFIG_RECREATE_REQ_CODE case when there's already a remote.