### PR TITLE
Add Backblaze B2 as a valid remote type when getting remote type from…

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/RemoteItem.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/RemoteItem.java
@@ -155,6 +155,8 @@ public class RemoteItem implements Comparable<RemoteItem>, Parcelable {
                 return AMAZON_DRIVE;
             case "s3":
                 return S3;
+            case "b2":
+                return B2;
             case "box":
                 return BOX;
             case "cache":


### PR DESCRIPTION
A bug introduced by 9861f22a. B2 was missing from the list of remote types.

This means hiding directory modified time stopped working for B2, since 17849872 will not work for B2 if the type returned is `-1` instead of `12`.