### PR TITLE
Show detailed modTime in properties dialog

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/FilePropertiesDialog.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/FilePropertiesDialog.java
@@ -70,7 +70,7 @@ public class FilePropertiesDialog extends DialogFragment {
         view = inflater.inflate(R.layout.dialog_file_properties, null);
 
         ((TextView)view.findViewById(R.id.filename)).setText(fileItem.getName());
-        ((TextView)view.findViewById(R.id.file_modtime)).setText(fileItem.getHumanReadableModTime());
+        ((TextView)view.findViewById(R.id.file_modtime)).setText(fileItem.getFormattedModTime());
         if (fileItem.isDir()) {
             view.findViewById(R.id.file_size).setVisibility(View.GONE);
             view.findViewById(R.id.file_size_label).setVisibility(View.GONE);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/FileItem.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/FileItem.java
@@ -4,6 +4,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.format.DateUtils;
 
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -19,6 +20,7 @@ public class FileItem implements Parcelable {
     private String humanReadableSize;
     private long modTime;
     private String humanReadableModTime;
+    private String formattedModTime;
     private boolean isDir;
 
     public FileItem(RemoteItem remote, String path, String name, long size, String modTime, String mimeType, boolean isDir) {
@@ -29,6 +31,7 @@ public class FileItem implements Parcelable {
         this.humanReadableSize = sizeToHumanReadable(size);
         this.modTime = modTimeToMilis(modTime);
         this.humanReadableModTime = modTimeToHumanReadable(modTime);
+        this.formattedModTime = modTimeToFormattedTime(modTime);
         this.mimeType = mimeType;
         this.isDir = isDir;
     }
@@ -41,6 +44,7 @@ public class FileItem implements Parcelable {
         humanReadableSize = in.readString();
         modTime = in.readLong();
         humanReadableModTime = in.readString();
+        formattedModTime = in.readString();
         mimeType = in.readString();
         isDir = in.readByte() != 0;
     }
@@ -78,6 +82,10 @@ public class FileItem implements Parcelable {
 
     public String getHumanReadableModTime() {
         return humanReadableModTime;
+    }
+
+    public String getFormattedModTime() {
+        return formattedModTime;
     }
 
     public long getModTime() {
@@ -152,6 +160,12 @@ public class FileItem implements Parcelable {
         return humanReadable.toString();
     }
 
+    private String modTimeToFormattedTime(String modTime) {
+        long modTimeInMillis = modTimeToMilis(modTime);
+        formattedModTime = DateFormat.getDateTimeInstance().format(modTimeInMillis);
+        return formattedModTime;
+    }
+
     @Override
     public boolean equals(Object obj) {
         return obj instanceof FileItem && ((FileItem) obj).getRemote().equals(this.remote) && ((FileItem) obj).getPath().equals(this.path) && ((FileItem) obj).getName().equals(this.name);
@@ -171,6 +185,7 @@ public class FileItem implements Parcelable {
         dest.writeString(humanReadableSize);
         dest.writeLong(modTime);
         dest.writeString(humanReadableModTime);
+        dest.writeString(formattedModTime);
         dest.writeString(mimeType);
         dest.writeByte((byte) (isDir ? 1 : 0));
     }

--- a/app/src/main/res/layout/dialog_file_properties.xml
+++ b/app/src/main/res/layout/dialog_file_properties.xml
@@ -35,7 +35,7 @@
         android:layout_height="wrap_content"
         android:textColor="?attr/textColorSecondary"
         android:textIsSelectable="true"
-        tools:text="May 30, 2018"/>
+        tools:text="May 30, 2018 1:23:45 PM"/>
 
     <TextView
         android:id="@+id/file_size_label"


### PR DESCRIPTION
To me it makes more sense to see the detailed modified time in the properties dialog (with the date and time), instead of just the simplified human readable date. The format should follow the local locale.

Hope you also agree with me!