### PR TITLE
Hide dir modTime in properties dialog for unsupported remotes

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/FilePropertiesDialog.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Dialogs/FilePropertiesDialog.java
@@ -71,7 +71,17 @@ public class FilePropertiesDialog extends DialogFragment {
         view = inflater.inflate(R.layout.dialog_file_properties, null);
 
         ((TextView)view.findViewById(R.id.filename)).setText(fileItem.getName());
-        ((TextView)view.findViewById(R.id.file_modtime)).setText(fileItem.getFormattedModTime());
+
+        RemoteItem itemRemote = fileItem.getRemote();
+        if (!itemRemote.isDirectoryModifiedTimeSupported() && fileItem.isDir()) {
+            view.findViewById(R.id.file_modtime_label).setVisibility(View.GONE);
+            view.findViewById(R.id.file_modtime).setVisibility(View.GONE);
+        } else {
+            view.findViewById(R.id.file_modtime_label).setVisibility(View.VISIBLE);
+            view.findViewById(R.id.file_modtime).setVisibility(View.VISIBLE);
+            ((TextView)view.findViewById(R.id.file_modtime)).setText(fileItem.getFormattedModTime());
+        }
+
         if (fileItem.isDir()) {
             view.findViewById(R.id.file_size).setVisibility(View.GONE);
             view.findViewById(R.id.file_size_label).setVisibility(View.GONE);

--- a/app/src/main/res/layout/dialog_file_properties.xml
+++ b/app/src/main/res/layout/dialog_file_properties.xml
@@ -23,6 +23,7 @@
         tools:text="Test file"/>
 
     <TextView
+        android:id="@+id/file_modtime_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="16dp"


### PR DESCRIPTION
This may help to avoid confusion since the modified time is hidden in the file explorer already, might as well hide it in the properties dialog too. Especially since the timestamp is invalid anyway.